### PR TITLE
Add support for helm secrets with vals backend

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -89,7 +89,9 @@ inputs:
     username:
         description: 'Chart repository username where to locate the requested chart.'
         required: false
-
+    use-secrets-vals:
+        description: 'Uses the secrets with vals backend to apply the chart'
+        required: false
 runs:
     using: 'docker'
     image: 'Dockerfile'
@@ -120,3 +122,4 @@ runs:
         REPO_USERNAME: ${{ inputs.username }}
         REPO_PASSWORD: ${{ inputs.password }}
         VERSION: ${{ inputs.version }}
+        USE_SECRETS_VALS: ${{ inputs.use-secrets-vals }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -124,8 +124,13 @@ fi
 # Proceed with installation procedure
 
 if [ "${HELM_ACTION}" == "install" ]; then
-    # Upgrade or install the chart.  This does it all.
-    HELM_COMMAND="helm upgrade --install --create-namespace --timeout ${TIMEOUT}  ${HELM_AUTH}"
+
+    if [ -n "${USE_SECRETS_VALS}" ]; then
+      HELM_COMMAND="helm secrets --backend vals --evaluate-templates true upgrade --install --create-namespace --timeout ${TIMEOUT}  ${HELM_AUTH}"
+    else
+      # Upgrade or install the chart.  This does it all.
+      HELM_COMMAND="helm upgrade --install --create-namespace --timeout ${TIMEOUT}  ${HELM_AUTH}"
+    fi
 
     # If we should wait, then do so
     if [ -n "${HELM_WAIT}" ]; then


### PR DESCRIPTION
by adding the proper plugin and setting the use-secrets-vals to true, this action will install the helm chart with secrets from vals backend