### PR TITLE
handle empty DEPLOY_CHART_PATH

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -194,7 +194,11 @@ HELM_COMMAND="${HELM_COMMAND} ${DEPLOY_NAME}"
 
 if [ "${HELM_ACTION}" == "install" ]; then
     if [ "${OCI_REGISTRY}" == "true" ]; then
-        DEPLOY_CHART_PATH="${HELM_REPOSITORY}/${DEPLOY_CHART_PATH}"
+        if [ -n "${DEPLOY_CHART_PATH}" ]; then
+            DEPLOY_CHART_PATH="${HELM_REPOSITORY}/${DEPLOY_CHART_PATH}"
+        else
+            DEPLOY_CHART_PATH="${HELM_REPOSITORY}"
+        fi
     fi
     HELM_COMMAND="${HELM_COMMAND} ${DEPLOY_CHART_PATH}"
 fi


### PR DESCRIPTION
When pulling from a ghci.io OCI repository, the deploy command will end up looking like this is the `chart-path` parameter is empty:

```
helm upgrade --install --create-namespace --timeout 600s --set web.tag=v0.1.2 --version v0.1.2 --dependency-update -n pkg pkg oci://ghcr.io/repo/pkg/
```

Which will result in the following error:
```
Error: invalid_reference: invalid repository
```

This patch will drop the trailing "/" which allows the `helm` command to succeed.