### PR TITLE
Make the --create-namespace parameter optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Following inputs can be used as `step.with` keys
 | `action`                   | String | Determines if we `install`/`uninstall` the chart, or `list`. (Optional, Defaults to `install`)                                                              |
 | `dry-run`                  | Boolean | Toggles `dry-run` option for `install`/`uninstall` action. (Defaults to `false`)                                                                           |
 | `config-files`             | String | Comma separated list of helm values files.                                                                                                                  |
-| `namespace`                | String | Kubernetes namespace to use.  Will create if it does not exist                                                                                              |
+| `namespace`                | String | Kubernetes namespace to use.  To create the namespace if it doesn't exist, also set `create-namespace` to `true`.    |
+| `create-namespace`         | Boolean | Adds `--create-namespace` when set to `true`. Requires cluster API permissions. (Default: `true`)                   |
 | `values`                   | String | Comma separated list of value set for helms. e.x:`key1=value1,key2=value2`                                                                                  |
 | `name`                     | String | The name of the helm release                                                                                                                                |
 | `chart-path`               | String | The path to the chart. (defaults to `helm/`)                                                                                                                |
@@ -100,6 +101,7 @@ Following inputs can be used as `step.with` keys
         config-files: fluent-bit/prod/values.yaml
         chart-path: fluent/fluent-bit
         namespace: logging
+        create-namespace: true
         name: fluent-bit
         chart-repository: https://fluent.github.io/helm-charts
         version: 0.20.6

--- a/action.yaml
+++ b/action.yaml
@@ -25,8 +25,12 @@ inputs:
         description: 'Comma separated list of helm values files.'
         required: false
     namespace:
-        description: 'Kubernetes namespace to use.'
+        description: 'Kubernetes namespace to target. (default: "default")'
         required: false
+    create-namespace:
+        description: 'Enable creating the namespace if it does not exist. Requires cluster API permissions.'
+        required: false
+        default: "true"
     values:
         description: 'Comma separated list of value sets for helms. e.x: key1=value1,key2=value2'
         required: false
@@ -106,6 +110,7 @@ runs:
         CLUSTER_ROLE_ARN: ${{ inputs.cluster-role-arn }}
         DEPLOY_CONFIG_FILES: ${{ inputs.config-files }}
         DEPLOY_NAMESPACE: ${{ inputs.namespace }}
+        CREATE_NAMESPACE: ${{ inputs.create-namespace }}
         DEPLOY_VALUES: ${{ inputs.values }}
         DEPLOY_NAME: ${{ inputs.name }}
         DEPLOY_CHART_PATH: ${{ inputs.chart-path }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -126,10 +126,10 @@ fi
 if [ "${HELM_ACTION}" == "install" ]; then
 
     if [ -n "${USE_SECRETS_VALS}" ]; then
-      HELM_COMMAND="helm secrets --backend vals --evaluate-templates true upgrade --install --create-namespace --timeout ${TIMEOUT}  ${HELM_AUTH}"
+      HELM_COMMAND="helm secrets --backend vals --evaluate-templates true upgrade --install --timeout ${TIMEOUT}  ${HELM_AUTH}"
     else
       # Upgrade or install the chart.  This does it all.
-      HELM_COMMAND="helm upgrade --install --create-namespace --timeout ${TIMEOUT}  ${HELM_AUTH}"
+      HELM_COMMAND="helm upgrade --install --timeout ${TIMEOUT}  ${HELM_AUTH}"
     fi
 
     # If we should wait, then do so
@@ -179,6 +179,12 @@ fi
 
 if [ -n "$DEPLOY_NAMESPACE" ]; then
     HELM_COMMAND="${HELM_COMMAND} -n ${DEPLOY_NAMESPACE}"
+fi
+
+# Create namespace if it doesn't exist. Requires cluster API permissions.
+# Will conflict with `list`, so don't set if in list mode
+if [ "${CREATE_NAMESPACE}" == "true" ] && [ "${HELM_ACTION}" != "list" ]; then
+    HELM_COMMAND="${HELM_COMMAND} --create-namespace"
 fi
 
 if [ "${HELM_ACTION}" == "list" ]; then


### PR DESCRIPTION
Add a new input parameter to enable/disable the addition of the `--create-namespace` flag in the computed Helm command.

* Because we haven't seen this issue before, I set it to default to `true`, so the behavior won't change (break) unless you specifically turn it off.
* The conditional _doesn't_ check if the `namespace` input is set, since `default` is a valid namespace, and is Helm's default if no value is passed.
* The `--create-namespace` flag is not valid as part of the `list` Helm action. So the conditional checks if the Helm Action is `list`, and won't add the flag if so.
* Added the input to Example 2 in the readme.

closes #54