### PR TITLE
Generate multiple set values commands

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -148,7 +148,10 @@ if [ "${HELM_ACTION}" == "install" ]; then
     done
 
     if [ -n "$DEPLOY_VALUES" ]; then
-        HELM_COMMAND="${HELM_COMMAND} --set ${DEPLOY_VALUES}"
+        for value in ${DEPLOY_VALUES//,/ }
+        do
+            HELM_COMMAND="${HELM_COMMAND} --set ${value}"
+        done
     fi
 
     if [ -n "$VERSION" ]; then


### PR DESCRIPTION
When passing particular values (in addition to or instead of value files), mostly for the values generated on runtime, one may end up with a huge long line of values, which is hard to read.
To make it more readable, I'd like to pass these values as a multi-line string, like this:

```
- name: Deploy
      uses: bitovi/github-actions-deploy-eks-helm
      with:
        ...
        values: |
          parameter1=value1,
          parameter2=value2,
          parameter3=value3,
          ...
```
However, the current code cannot parse multi-line `values` input, which leads to helm error.
This PR allows putting values in a described way, basically the same way it's done for the value files (the `config-files` input).