### PR TITLE
Fix create-namespace to only apply to install

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -38,7 +38,7 @@ inputs:
         description: 'Name of the helm deploy.'
         required: true
     action:
-        description: 'Specify whether you want to install or uninstall the target helm chart'
+        description: 'Specify whether you want to list, install or uninstall the target helm chart'
         required: false
         default: 'install'
     dry-run:

--- a/deploy.sh
+++ b/deploy.sh
@@ -195,8 +195,8 @@ if [ -n "$DEPLOY_NAMESPACE" ]; then
 fi
 
 # Create namespace if it doesn't exist. Requires cluster API permissions.
-# Will conflict with `list`, so don't set if in list mode
-if [ "${CREATE_NAMESPACE}" == "true" ] && [ "${HELM_ACTION}" != "list" ]; then
+# Only applies to `install` option. `helm upgrade` is not used.
+if [ "${CREATE_NAMESPACE}" == "true" ] && [ "${HELM_ACTION}" == "install" ]; then
     HELM_COMMAND="${HELM_COMMAND} --create-namespace"
 fi
 


### PR DESCRIPTION
The `--create-namespace` option was being passed to `helm uninstall` and is not a valid option for that command. It only needs to be passed with action `install`.

Also:
* Add the list as an option for the action input in the action.yaml